### PR TITLE
[WIP] Add filter categories to MAX and DAX assets

### DIFF
--- a/dataset-samples/fpb.yaml
+++ b/dataset-samples/fpb.yaml
@@ -9,6 +9,12 @@ format:
     url: https://universaldependencies.org/format.html
 domain: Natural Language Processing
 
+# applicable filter categories for MLX UI
+filter_categories:
+  domain: NLP
+  format: text
+  sector: finance
+
 # Information about the entity that makes the data set available
 provider:
   name: Data Asset eXchange

--- a/model-samples/max-human-pose-estimator.yaml
+++ b/model-samples/max-human-pose-estimator.yaml
@@ -20,6 +20,14 @@ license: "Apache 2.0"
 domain: "Human Pose Estimation"
 website: "https://developer.ibm.com/exchanges/models/all/max-human-pose-estimator/"
 
+# applicable filter categories for MLX UI
+filter_categories:
+  domain: image-recognition
+  platform:
+    - kubernetes
+    - kfserving
+  language: python
+
 serve:
   servable: true
   tested_platforms:

--- a/model-samples/max-image-caption-generator.yaml
+++ b/model-samples/max-image-caption-generator.yaml
@@ -15,10 +15,16 @@ model_identifier: max-image-caption-generator
 description: "IBM Model Asset eXchange(MAX) model that generates captions from a fixed vocabulary describing the contents of images in the COCO dataset"
 framework:
     name: tensorflow
-
 license: "Apache 2.0"
 domain: "Image-To-Text Translation"
 website: "https://developer.ibm.com/exchanges/models/all/max-image-caption-generator/"
+
+# applicable filter categories for MLX UI
+filter_categories:
+  domain: "image-to-text"
+  platform: ["kubernetes", "kfserving"]
+  language: "python"
+  framework: "tensorflow"
 
 serve:
   servable: true


### PR DESCRIPTION
**Changes in this PR:**
* Add `filter_categories` to DAX datasets and MAX models
  ```YAML
  filter_categories:
    domain: "image-to-text"
    platform: 
      - "kubernetes"
      - "kfserving"
    language: "python"
    framework: "tensorflow"
  ```

**Related issues:**
https://github.com/machine-learning-exchange/mlx/pull/167
https://github.com/machine-learning-exchange/mlx/pull/183