### PR TITLE
Shorten CodeNet Dataset descriptions

### DIFF
--- a/dataset-samples/codenet/codenet.yaml
+++ b/dataset-samples/codenet/codenet.yaml
@@ -1,5 +1,5 @@
 id: codenet
-name: CodeNet Dataset
+name: Project CodeNet
 description: Project CodeNet is a large-scale dataset with approximately 14 million code samples, each of which is an intended solution to one of 4000 coding problems.
 version: 1.0.0
 created: 2021-05-05

--- a/dataset-samples/codenet_langclass/codenet_langclass.yaml
+++ b/dataset-samples/codenet_langclass/codenet_langclass.yaml
@@ -1,6 +1,6 @@
 id: codenet_langclass
-name: Project CodeNet - LangClass subset
-description: Project CodeNet is a large-scale dataset with approximately 14 million code samples, each of which is an intended solution to one of 4000 coding problems. This small subset of the Project CodeNet dataset is intended to showcase a language classification model and only comprises 2198 random samples across 10 languages.
+name: Project CodeNet - Language Classifier
+description: A small subset of the Project CodeNet dataset, intended to showcase a language classification model. It only comprises 2198 random samples across 10 languages.
 version: 1.0.0
 created: 2021-05-05
 updated: 2021-05-05

--- a/dataset-samples/codenet_mlm/codenet_mlm.yaml
+++ b/dataset-samples/codenet_mlm/codenet_mlm.yaml
@@ -1,12 +1,12 @@
 id: codenet_mlm
-name: Project CodeNet - MLM subset
-description: Project CodeNet is a large-scale dataset with approximately 14 million code samples, each of which is an intended solution to one of 4000 coding problems. This small subset contains 55,000 samples in the C programming language to demonstrate the use of a Masked-Language Model for tokenization tasks.
+name: Project CodeNet - Masked Language Model
+description: A small subset of the Project CodeNet dataset, containing 55,000 samples in the C programming language to demonstrate the use of a Masked Language Model for tokenization tasks.
 version: 1.0.0
 created: 2021-05-05
 updated: 2021-05-05
 format:
   - type: C
-    url: https://en.wikipedia.org/wiki/Programming_language
+    url: https://en.wikipedia.org/wiki/The_C_Programming_Language
 domain: Solutions to Programming Problems
 
 # Information about the entity that makes the data set available


### PR DESCRIPTION
Need to shorten the description of the new CodeNet datasets. Maximum length of descriptions is 255 characters due to the datatype `varchar(255)` being used to store descriptions in MySQL. 

Related: machine-learning-exchange/mlx#208
