### PR TITLE
Downgrade CodeNet Notebook Requirements Versions

### DIFF
--- a/notebook-samples/codenet-lang.yaml
+++ b/notebook-samples/codenet-lang.yaml
@@ -21,4 +21,4 @@ implementation: # required
     source: 'https://github.com/machine-learning-exchange/katalog/blob/main/notebook-samples/src/codenet/Project_CodeNet_LangClass.ipynb'
     # TODO: do not require '==' in elyra-ai/kfp-notebook:"bootstrapper.py", def package_list_to_dict()
     #   https://github.com/elyra-ai/kfp-notebook/blob/v0.26.0/etc/docker-scripts/bootstrapper.py#L548
-    requirements: 'matplotlib==3.4.3,numpy==1.19.5,tensorflow==2.6.0'
+    requirements: 'matplotlib==3.3.4,numpy==1.19.5,tensorflow==2.6.0'

--- a/notebook-samples/codenet-lang.yaml
+++ b/notebook-samples/codenet-lang.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: 'Project CodeNet Language Classification' # required
-description: 'Simple experiment that shows how to create and exercise a Keras model to detect the language of a piece of source code' # Optional
-metadata: # Optional metadata
+
+name: 'Project CodeNet Language Classification'
+description: 'Simple experiment that shows how to create and exercise a Keras model to detect the language of a piece of source code'
+metadata:
   annotations:
     platform: 'OpenSource'
-implementation: # required
+implementation:
   github:
     source: 'https://github.com/machine-learning-exchange/katalog/blob/main/notebook-samples/src/codenet/Project_CodeNet_LangClass.ipynb'
-    # TODO: do not require '==' in elyra-ai/kfp-notebook:"bootstrapper.py", def package_list_to_dict()
-    #   https://github.com/elyra-ai/kfp-notebook/blob/v0.26.0/etc/docker-scripts/bootstrapper.py#L548
     requirements: 'matplotlib==3.3.4,numpy==1.19.5,tensorflow==2.6.0'

--- a/notebook-samples/codenet-mlm.yaml
+++ b/notebook-samples/codenet-mlm.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: 'Project CodeNet Masked Language Model' # required
-description: 'Experiment investigates whether a popular attention model to construct a masked language model (MLM) can be used for source code instead of natural language sentences' # Optional
-metadata: # Optional metadata
+
+name: 'Project CodeNet Masked Language Model'
+description: 'Experiment investigates whether a popular attention model to construct a masked language model (MLM) can be used for source code instead of natural language sentences'
+metadata:
   annotations:
     platform: 'OpenSource'
-implementation: # required
+implementation:
   github:
     source: 'https://github.com/machine-learning-exchange/katalog/blob/main/notebook-samples/src/codenet/Project_CodeNet_MLM.ipynb'
-    # TODO: do not require '==' in elyra-ai/kfp-notebook:"bootstrapper.py", def package_list_to_dict()
-    #   https://github.com/elyra-ai/kfp-notebook/blob/v0.26.0/etc/docker-scripts/bootstrapper.py#L548
-    requirements: 'pandas==1.1.5,tensorflow==2.6.0'
+    requirements: 'matplotlib==3.3.4,pandas==1.1.5,tensorflow==2.6.0'

--- a/notebook-samples/codenet-mlm.yaml
+++ b/notebook-samples/codenet-mlm.yaml
@@ -21,4 +21,4 @@ implementation: # required
     source: 'https://github.com/machine-learning-exchange/katalog/blob/main/notebook-samples/src/codenet/Project_CodeNet_MLM.ipynb'
     # TODO: do not require '==' in elyra-ai/kfp-notebook:"bootstrapper.py", def package_list_to_dict()
     #   https://github.com/elyra-ai/kfp-notebook/blob/v0.26.0/etc/docker-scripts/bootstrapper.py#L548
-    requirements: 'pandas==1.3.2,tensorflow==2.6.0'
+    requirements: 'pandas==1.1.5,tensorflow==2.6.0'


### PR DESCRIPTION
There seems to be a networking issue on our IKS cluster where pip install cannot find the latest package versions on PyPI. But apearantly the Elyra `kfp-notebook` image we are using to run notebooks has some slightly older versions in the package cache. So, for now we can just downgrade some of our dependencies.

**Errors**:

```
ERROR: Could not find a version that satisfies the requirement pandas==1.3.2 (from versions: 0.1, 0.2b0, 0.2b1, 0.2, 0.3.0b0, 0.3.0b2, 0.3.0, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.5.0, 0.6.0, 0.6.1, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.8.0rc1, 0.8.0, 0.8.1, 0.9.0, 0.9.1, 0.10.0, 0.10.1, 0.11.0, 0.12.0, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.15.0, 0.15.1, 0.15.2, 0.16.0, 0.16.1, 0.16.2, 0.17.0, 0.17.1, 0.18.0, 0.18.1, 0.19.0, 0.19.1, 0.19.2, 0.20.0, 0.20.1, 0.20.2, 0.20.3, 0.21.0, 0.21.1, 0.22.0, 0.23.0, 0.23.1, 0.23.2, 0.23.3, 0.23.4, 0.24.0, 0.24.1, 0.24.2, 0.25.0, 0.25.1, 0.25.2, 0.25.3, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5)
ERROR: No matching distribution found for pandas==1.3.2
WARNING: You are using pip version 20.2.4; however, version 21.2.4 is available.
You should consider upgrading via the '/usr/bin/python3 -m pip install --upgrade pip' command.
Traceback (most recent call last):
  File "bootstrapper.py", line 629, in <module>
    main()
  File "bootstrapper.py", line 612, in main
    OpUtil.package_install(user_volume_path=input_params.get('user-volume-path'))
  File "bootstrapper.py", line 528, in package_install
    subprocess.run([sys.executable, '-m', 'pip', 'install'] + to_install_list, check=True)
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/python3', '-m', 'pip', 'install', 'pandas==1.3.2', 'tensorflow==2.6.0', 'ipykernel==5.3.0', 'ipython==7.15.0', 'ipython-genutils==0.2.0', 'jupyter-client==6.1.6', 'jupyter-core==4.6.3', 'minio==6.0.2', 'nbclient==0.4.1', 'nbconvert==5.6.1', 'nbformat==5.0.7', 'papermill==2.1.2', 'pyzmq==19.0.1', 'prompt-toolkit==3.0.5', 'tornado==6.0.4', 'traitlets==4.3.3']' returned non-zero exit status 1.
Runtime execution graph. Only steps that are currently running or have already completed are shown.
``` 

```
ERROR: Could not find a version that satisfies the requirement matplotlib==3.4.3 (from versions: 0.86, 0.86.1, 0.86.2, 0.91.0, 0.91.1, 1.0.1, 1.1.0, 1.1.1, 1.2.0, 1.2.1, 1.3.0, 1.3.1, 1.4.0, 1.4.1rc1, 1.4.1, 1.4.2, 1.4.3, 1.5.0, 1.5.1, 1.5.2, 1.5.3, 2.0.0b1, 2.0.0b2, 2.0.0b3, 2.0.0b4, 2.0.0rc1, 2.0.0rc2, 2.0.0, 2.0.1, 2.0.2, 2.1.0rc1, 2.1.0, 2.1.1, 2.1.2, 2.2.0rc1, 2.2.0, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 3.0.0rc2, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0rc1, 3.1.0rc2, 3.1.0, 3.1.1, 3.1.2, 3.1.3, 3.2.0rc1, 3.2.0rc3, 3.2.0, 3.2.1, 3.2.2, 3.3.0rc1, 3.3.0, 3.3.1, 3.3.2, 3.3.3, 3.3.4)
ERROR: No matching distribution found for matplotlib==3.4.3
WARNING: You are using pip version 20.2.4; however, version 21.2.4 is available.
You should consider upgrading via the '/usr/bin/python3 -m pip install --upgrade pip' command.
Traceback (most recent call last):
  File "bootstrapper.py", line 629, in <module>
    main()
  File "bootstrapper.py", line 612, in main
    OpUtil.package_install(user_volume_path=input_params.get('user-volume-path'))
  File "bootstrapper.py", line 528, in package_install
    subprocess.run([sys.executable, '-m', 'pip', 'install'] + to_install_list, check=True)
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/python3', '-m', 'pip', 'install', 'matplotlib==3.4.3', 'tensorflow==2.6.0', 'ipykernel==5.3.0', 'ipython==7.15.0', 'ipython-genutils==0.2.0', 'jupyter-client==6.1.6', 'jupyter-core==4.6.3', 'minio==6.0.2', 'nbclient==0.4.1', 'nbconvert==5.6.1', 'nbformat==5.0.7', 'papermill==2.1.2', 'pyzmq==19.0.1', 'prompt-toolkit==3.0.5', 'tornado==6.0.4', 'traitlets==4.3.3']' returned non-zero exit status 1.
Runtime execution graph. Only steps that are currently running or have already completed are shown.
```