### PR TITLE
Replace '_' with '-' in CodeNet dataset IDs

### DIFF
--- a/dataset-samples/codenet_langclass/codenet_langclass.yaml
+++ b/dataset-samples/codenet_langclass/codenet_langclass.yaml
@@ -1,4 +1,4 @@
-id: codenet_langclass
+id: codenet-langclass
 name: Project CodeNet - Language Classifier
 description: A small subset of the Project CodeNet dataset, intended to showcase a language classification model. It only comprises 2198 random samples across 10 languages.
 version: 1.0.0

--- a/dataset-samples/codenet_mlm/codenet_mlm.yaml
+++ b/dataset-samples/codenet_mlm/codenet_mlm.yaml
@@ -1,4 +1,4 @@
-id: codenet_mlm
+id: codenet-mlm
 name: Project CodeNet - Masked Language Model
 description: A small subset of the Project CodeNet dataset, containing 55,000 samples in the C programming language to demonstrate the use of a Masked Language Model for tokenization tasks.
 version: 1.0.0


### PR DESCRIPTION
The dataset `id` is used by the Datashim PVC mounting component for field `"metadata.name"` and must be a DNS-1123 subdomain consisting of lower case alphanumeric characters, '-' or '.'

Related: machine-learning-exchange/mlx#209

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>