### PR TITLE
Rename the Masked Language Model dataset and notebook

### DIFF
--- a/dataset-samples/codenet_mlm/codenet_mlm.md
+++ b/dataset-samples/codenet_mlm/codenet_mlm.md
@@ -1,5 +1,6 @@
 ## Overview
-**Note**: This small subset contains 55,000 samples in the C programming language to demonstrate the use of a Masked-Language Model for tokenization tasks.
+**Note**: This small subset contains 55,000 samples in the C programming language to demonstrate the use of a Masked 
+Language Model (MLM) for tokenization tasks.
 
 Project CodeNet is a large-scale dataset with approximately 14 million code samples, each of which is an intended solution to one of 4000 coding problems. The code samples are obtained from downloading submissions from two online judge web sites: [AIZU Online Judge](https://judge.u-aizu.ac.jp/onlinejudge/) and [AtCoder](https://atcoder.jp/). The code samples are written in over 50 programming languages (although the dominant languages are C++, C, Python, and Java) and they are annotated with a rich set of information, such as its code size, memory footprint, cpu run time, and status, which indicates acceptance or error types. The dataset is accompanied by a [repository](https://github.com/IBM/Project_CodeNet), where we provide a set of [tools](https://github.com/IBM/Project_CodeNet/tree/main/tools) to aggregate codes samples based on user criteria and to transform code samples into token sequences, simplified parse trees and other code graphs. A detailed discussion of Project CodeNet is available in this [paper](https://github.com/IBM/Project_CodeNet/blob/main/ProjectCodeNet.pdf).
 

--- a/dataset-samples/codenet_mlm/codenet_mlm.yaml
+++ b/dataset-samples/codenet_mlm/codenet_mlm.yaml
@@ -1,5 +1,5 @@
 id: codenet-mlm
-name: Project CodeNet - Masked Language Model
+name: Project CodeNet - MLM
 description: A small subset of the Project CodeNet dataset, containing 55,000 samples in the C programming language to demonstrate the use of a Masked Language Model for tokenization tasks.
 version: 1.0.0
 created: 2021-05-05
@@ -56,7 +56,7 @@ related_assets:
     url: https://github.com/machine-learning-exchange/katalog/blob/main/notebook-samples/src/codenet/Project_CodeNet_MLM.ipynb
     application:
       name: MLX
-      asset_id: notebooks/project-codenet-masked-language-model
+      asset_id: notebooks/project-codenet-mlm
 
 # OPTIONAL; url for the markdown file which describes the asset
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/codenet_mlm/codenet_mlm.md

--- a/notebook-samples/codenet-lang.yaml
+++ b/notebook-samples/codenet-lang.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Project CodeNet Language Classification'
+name: 'Project CodeNet - Language Classification'
 description: 'Simple experiment that shows how to create and exercise a Keras model to detect the language of a piece of source code'
 metadata:
   annotations:

--- a/notebook-samples/codenet-mlm.yaml
+++ b/notebook-samples/codenet-mlm.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Project CodeNet Masked Language Model'
+name: 'Project CodeNet - MLM'
 description: 'Experiment investigates whether a popular attention model to construct a masked language model (MLM) can be used for source code instead of natural language sentences'
 metadata:
   annotations:


### PR DESCRIPTION
Requested by @animeshsingh 

> It may be confusing to see the title "Masked Language Model" for a dataset or notebook (both of which are not "models")

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>