### PR TITLE
Remove "MAX" prefix from model names

### DIFF
--- a/model-samples/README.md
+++ b/model-samples/README.md
@@ -10,7 +10,7 @@ The [template](template.yaml) describes the metadata spec:
 
 - **(Required)**: Fields that are Always required in all condition.
 - **(Required for xxx)**: Fields that are required when trainable/servable or certain storage type is specified.
-- **(optional)**: Fields that can be omit, but do not put empty strings since it will overwrite the default values.
+- **(optional)**: Fields that can be omitted, but do not put empty strings since it will overwrite the default values.
 
 ### Metadata template for a trainable model
 
@@ -111,13 +111,13 @@ Models can be run based on the metadata specified in the YAML file for a particu
 
 
 ## List of Sample Models
-* [MAX Human Pose Estimator](max-human-pose-estimator.yaml)
-* [MAX Image Caption Generator](max-image-caption-generator.yaml)
-* [MAX Image Resolution Enhancer](max-image-resolution-enhancer.yaml)
-* [MAX Object Detector](max-object-detector.yaml)
-* [MAX Optical Character Recognition](max-ocr.yaml)
-* [MAX Question Answering](max-question-answering.yaml)
-* [MAX Recommender System](max-recommender.yaml)
-* [MAX Text Sentiment Classifier](max-text-sentiment-classifier.yaml)
-* [MAX Toxic Comment Classifier](max-toxic-comment-classifier.yaml)
-* [MAX Weather Forecaster](max-weather-forecaster.yaml)
+* [Human Pose Estimator](max-human-pose-estimator.yaml)
+* [Image Caption Generator](max-image-caption-generator.yaml)
+* [Image Resolution Enhancer](max-image-resolution-enhancer.yaml)
+* [Object Detector](max-object-detector.yaml)
+* [Optical Character Recognition](max-ocr.yaml)
+* [Question Answering](max-question-answering.yaml)
+* [Recommender System](max-recommender.yaml)
+* [Text Sentiment Classifier](max-text-sentiment-classifier.yaml)
+* [Toxic Comment Classifier](max-toxic-comment-classifier.yaml)
+* [Weather Forecaster](max-weather-forecaster.yaml)

--- a/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
+++ b/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Human Pose Estimator
+name: Human Pose Estimator
 model_identifier: max-human-pose-estimator
 description: IBM Model Asset eXchange(MAX) model that detects humans in an image and estimate the pose for each person.
 framework:

--- a/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
+++ b/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Image Caption Generator
+name: Image Caption Generator
 model_identifier: max-image-caption-generator
 description: "IBM Model Asset eXchange(MAX) model that generates captions from a fixed vocabulary describing the contents of images in the COCO dataset"
 framework:

--- a/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
+++ b/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Image Resolution Enhancer
+name: Image Resolution Enhancer
 model_identifier: max-image-resolution-enhancer
 description: IBM Model Asset eXchange(MAX) model that upscales an image by a factor of 4, while generating photo-realistic details.
 framework:

--- a/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
+++ b/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Named Entity Tagger
+name: Named Entity Tagger
 model_identifier: max-named-entity-tagger
 description: IBM Model Asset eXchange(MAX) model that locates and tags named entities in text.
 framework:

--- a/model-samples/max-object-detector/max-object-detector.yaml
+++ b/model-samples/max-object-detector/max-object-detector.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Object Detector
+name: Object Detector
 model_identifier: max-object-detector
 description: IBM Model Asset eXchange(MAX) model that localizes and identifies multiple objects in a single image
 framework:

--- a/model-samples/max-ocr/max-ocr.yaml
+++ b/model-samples/max-ocr/max-ocr.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Optical Character Recognition
+name: Optical Character Recognition
 model_identifier: max-ocr
 description: IBM Model Asset eXchange(MAX) model that identifies text in an image.
 framework:

--- a/model-samples/max-question-answering/max-question-answering.yaml
+++ b/model-samples/max-question-answering/max-question-answering.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Question Answering
+name: Question Answering
 model_identifier: max-question-answering
 description: IBM Model Asset eXchange(MAX) model that answers questions on a given corpus of text
 framework:

--- a/model-samples/max-recommender/max-recommender.yaml
+++ b/model-samples/max-recommender/max-recommender.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Recommender System
+name: Recommender System
 model_identifier: max-recommender
 description: IBM Model Asset eXchange(MAX) model that generates personalized recommendations
 framework:

--- a/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
+++ b/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Text Sentiment Classifier
+name: Text Sentiment Classifier
 model_identifier: max-text-sentiment-classifier
 description: IBM Model Asset eXchange(MAX) model that detects the sentiment captured in short pieces of text
 framework:

--- a/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
+++ b/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Toxic Comment Classifier
+name: Toxic Comment Classifier
 model_identifier: max-toxic-comment-classifier
 description: IBM Model Asset eXchange(MAX) model that detects 6 types of toxicity in user comments
 framework:

--- a/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
+++ b/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: MAX Weather Forecaster
+name: Weather Forecaster
 model_identifier: max-weather-forecaster
 description: IBM Model Asset eXchange(MAX) model that predicts hourly weather features given historical data for a specific location
 framework:


### PR DESCRIPTION
Changes in this PR, part of issue #47 :

- [x] Update the `name`s in model YAMLs,  keep old `model_identifier` 
- [x] Update the list of models in [model-samples/README.md](https://github.com/machine-learning-exchange/katalog/tree/main/model-samples#list-of-sample-models)


**Related issues:**
- [ ] #47
> - [x] model YAMLs, `name` 
> - [x] list of models in [model-samples/README.md](https://github.com/machine-learning-exchange/katalog/tree/main/model-samples#list-of-sample-models)
- [ ] machine-learning-exchange/mlx#224

