### PR TITLE
Add SPDX license headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 # Acknowledgements:
 #  - The help target was derived from https://stackoverflow.com/a/35730328/5601796

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,9 @@ check_doc_links: ## Check Markdown files for valid links
 	@pip3 show requests > /dev/null || pip3 install requests
 	@python3 tools/python/verify_doc_links.py
 	@echo "$@: OK"
+
+.PHONY: check_license
+check_license: ## Make sure source files have license header
+	@git grep -L "SPDX-License-Identifier: Apache-2.0" -- *.py *.yml *.yaml *.sh *.html *.js *.css *.ts *.tsx ':!*.bundle.js' | \
+		grep . && echo "Missing license headers in files above. Run './tools/bash/add_license_headers.sh'" && exit 1 || \
+		echo "$@: OK"

--- a/component-samples/create-secret/component.yaml
+++ b/component-samples/create-secret/component.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: 'Create Secret - Kubernetes Cluster'
 description: |

--- a/component-samples/create-secret/component.yaml
+++ b/component-samples/create-secret/component.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: 'Create Secret - Kubernetes Cluster'

--- a/component-samples/create-secret/src/config.py
+++ b/component-samples/create-secret/src/config.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 if __name__ == "__main__":
     import argparse

--- a/component-samples/create-secret/src/config.py
+++ b/component-samples/create-secret/src/config.py
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 if __name__ == "__main__":

--- a/component-samples/dax-to-dlf/component.yaml
+++ b/component-samples/dax-to-dlf/component.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 name: Generate Dataset Metadata
 description: Convert Data Asset EXchange YAML files to Dataset Lifecycle Framework YAML files
 inputs:

--- a/component-samples/dax-to-dlf/component.yaml
+++ b/component-samples/dax-to-dlf/component.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 name: Generate Dataset Metadata

--- a/component-samples/dax-to-dlf/src/dataset_converter.py
+++ b/component-samples/dax-to-dlf/src/dataset_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 import argparse

--- a/component-samples/dax-to-dlf/src/dataset_converter.py
+++ b/component-samples/dax-to-dlf/src/dataset_converter.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 import yaml

--- a/component-samples/dax-to-dlf/tests/dax_example.yaml
+++ b/component-samples/dax-to-dlf/tests/dax_example.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 id: noaa-weather-data–jfk-airport

--- a/component-samples/dax-to-dlf/tests/dax_example.yaml
+++ b/component-samples/dax-to-dlf/tests/dax_example.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 id: noaa-weather-data–jfk-airport
 name: NOAA Weather Data – JFK Airport
 description: Local climatological data originally collected at JFK airport.

--- a/component-samples/dax-to-dlf/tests/dax_to_dlf_pipeline.py
+++ b/component-samples/dax-to-dlf/tests/dax_to_dlf_pipeline.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 import yaml
 
 from kfp import components

--- a/component-samples/dax-to-dlf/tests/dax_to_dlf_pipeline.py
+++ b/component-samples/dax-to-dlf/tests/dax_to_dlf_pipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 import yaml

--- a/component-samples/dax-to-dlf/tests/dlf_example.yaml
+++ b/component-samples/dax-to-dlf/tests/dlf_example.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: com.ie.ibm.hpsys/v1alpha1
 kind: Dataset
 metadata:

--- a/component-samples/dax-to-dlf/tests/dlf_example.yaml
+++ b/component-samples/dax-to-dlf/tests/dlf_example.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: com.ie.ibm.hpsys/v1alpha1

--- a/component-samples/dlf/component.yaml
+++ b/component-samples/dlf/component.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 name: Create Dataset Volume
 description: Manage Dataset Lifecycle Framework datasets
 inputs:

--- a/component-samples/dlf/component.yaml
+++ b/component-samples/dlf/component.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 name: Create Dataset Volume

--- a/component-samples/dlf/src/dataset_manager.py
+++ b/component-samples/dlf/src/dataset_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/component-samples/dlf/src/dataset_manager.py
+++ b/component-samples/dlf/src/dataset_manager.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 import json
 import argparse
 import os

--- a/component-samples/dlf/tests/dlf_example.yaml
+++ b/component-samples/dlf/tests/dlf_example.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: com.ie.ibm.hpsys/v1alpha1
 kind: Dataset
 metadata:

--- a/component-samples/dlf/tests/dlf_example.yaml
+++ b/component-samples/dlf/tests/dlf_example.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: com.ie.ibm.hpsys/v1alpha1

--- a/component-samples/dlf/tests/dlf_pipeline.py
+++ b/component-samples/dlf/tests/dlf_pipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 import kfp.dsl as dsl

--- a/component-samples/dlf/tests/dlf_pipeline.py
+++ b/component-samples/dlf/tests/dlf_pipeline.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 import kfp.dsl as dsl
 import kfp
 from kfp import components

--- a/component-samples/echo/component.yaml
+++ b/component-samples/echo/component.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 name: Echo Sample

--- a/component-samples/echo/component.yaml
+++ b/component-samples/echo/component.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 name: Echo Sample
 description: |
   Sample component for testing

--- a/component-samples/kube-model-deployment/component.yaml
+++ b/component-samples/kube-model-deployment/component.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 name: 'Kubernetes model deploy'
 description: |
   Deploy AI models using Kubernetes deployment.

--- a/component-samples/kube-model-deployment/component.yaml
+++ b/component-samples/kube-model-deployment/component.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 name: 'Kubernetes model deploy'

--- a/component-samples/kube-model-deployment/src/app.py
+++ b/component-samples/kube-model-deployment/src/app.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 # 
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
-# You may obtain a copy of the License at 
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0 
-# 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
-# limitations under the License. 
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import json

--- a/component-samples/kube-model-deployment/src/app.py
+++ b/component-samples/kube-model-deployment/src/app.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 # 
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/component-samples/kube-model-deployment/src/kube_deployment.py
+++ b/component-samples/kube-model-deployment/src/kube_deployment.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation 
+# Copyright 2021 The MLX Contributors 
 # 
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/component-samples/kube-model-deployment/src/kube_deployment.py
+++ b/component-samples/kube-model-deployment/src/kube_deployment.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation 
 # 
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
-# You may obtain a copy of the License at 
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0 
-# 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
-# limitations under the License. 
+# SPDX-License-Identifier: Apache-2.0
 import json
 import argparse
 import requests

--- a/component-samples/model-config/component.yaml
+++ b/component-samples/model-config/component.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 name: Create Model Config

--- a/component-samples/model-config/component.yaml
+++ b/component-samples/model-config/component.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 name: Create Model Config
 description:
 inputs:

--- a/component-samples/model-config/src/model-config.py
+++ b/component-samples/model-config/src/model-config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/component-samples/model-config/src/model-config.py
+++ b/component-samples/model-config/src/model-config.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 import json
 import argparse
 import requests

--- a/component-samples/template.yaml
+++ b/component-samples/template.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: <Component Name>

--- a/component-samples/template.yaml
+++ b/component-samples/template.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: <Component Name>
 description: <Component Description>

--- a/dataset-samples/codenet/codenet.yaml
+++ b/dataset-samples/codenet/codenet.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: codenet
 name: Project CodeNet
 description: Project CodeNet is a large-scale dataset with approximately 14 million code samples, each of which is an intended solution to one of 4000 coding problems.

--- a/dataset-samples/codenet_langclass/codenet_langclass.yaml
+++ b/dataset-samples/codenet_langclass/codenet_langclass.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: codenet-langclass
 name: Project CodeNet - Language Classifier
 description: A small subset of the Project CodeNet dataset, intended to showcase a language classification model. It only comprises 2198 random samples across 10 languages.

--- a/dataset-samples/codenet_mlm/codenet_mlm.yaml
+++ b/dataset-samples/codenet_mlm/codenet_mlm.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: codenet-mlm
 name: Project CodeNet - MLM
 description: A small subset of the Project CodeNet dataset, containing 55,000 samples in the C programming language to demonstrate the use of a Masked Language Model for tokenization tasks.

--- a/dataset-samples/fpb/fpb.yaml
+++ b/dataset-samples/fpb/fpb.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: finance-proposition-bank
 name: Finance Proposition Bank
 description: Text from approximately 1000 English sentences obtained from IBM's public annual financial reports, annotated with a layer of 'universal' semantic role labels.

--- a/dataset-samples/gmb/gmb.yaml
+++ b/dataset-samples/gmb/gmb.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: groningen-meaning-bank-modified
 name: Groningen Meaning Bank - Modified
 description: A subset of the GMB dataset, consisting of documents verified to be in the public domain.

--- a/dataset-samples/jfk/jfk.yaml
+++ b/dataset-samples/jfk/jfk.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: noaa-weather-data-jfk-airport
 name: NOAA Weather Data - JFK Airport
 description: Local climatological data originally collected at JFK airport.

--- a/dataset-samples/publaynet/publaynet.yaml
+++ b/dataset-samples/publaynet/publaynet.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: publaynet
 name: PubLayNet
 description: PubLayNet is a large dataset of document images from PubMed Central Open Access Subset. Each document’s layout is annotated with both bounding boxes and polygonal segmentations.

--- a/dataset-samples/pubtabnet/pubtabnet.yaml
+++ b/dataset-samples/pubtabnet/pubtabnet.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: pubtabnet
 name: PubTabNet
 description: PubTabNet is a large dataset for image-based table recognition, containing 516k+ images of tabular data annotated with the corresponding HTML representation of the tables.

--- a/dataset-samples/thematic_clustering/thematic_clustering.yaml
+++ b/dataset-samples/thematic_clustering/thematic_clustering.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: thematic-clustering-of-sentences
 name: IBM Debater® Thematic Clustering of Sentences
 description: A benchmark of sentence-clustering based on the partition of Wikipedia articles into sections.

--- a/dataset-samples/tsc/tsc.yaml
+++ b/dataset-samples/tsc/tsc.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 id: tensorflow-speech-commands
 name: TensorFlow Speech Commands
 description: A collection of short clips of spoken English words.

--- a/model-samples/codenet-language-classification/codenet-language-classification.yaml
+++ b/model-samples/codenet-language-classification/codenet-language-classification.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/model-samples/codenet-language-classification/codenet-language-classification.yaml
+++ b/model-samples/codenet-language-classification/codenet-language-classification.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: CodeNet Language Classification
 model_identifier: codenet-language-classification

--- a/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
+++ b/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Human Pose Estimator

--- a/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
+++ b/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Human Pose Estimator
 model_identifier: max-human-pose-estimator

--- a/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
+++ b/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Image Caption Generator
 model_identifier: max-image-caption-generator

--- a/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
+++ b/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Image Caption Generator

--- a/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
+++ b/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Image Resolution Enhancer

--- a/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
+++ b/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Image Resolution Enhancer
 model_identifier: max-image-resolution-enhancer

--- a/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
+++ b/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Named Entity Tagger

--- a/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
+++ b/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Named Entity Tagger
 model_identifier: max-named-entity-tagger

--- a/model-samples/max-object-detector/max-object-detector.yaml
+++ b/model-samples/max-object-detector/max-object-detector.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Object Detector

--- a/model-samples/max-object-detector/max-object-detector.yaml
+++ b/model-samples/max-object-detector/max-object-detector.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Object Detector
 model_identifier: max-object-detector

--- a/model-samples/max-ocr/max-ocr.yaml
+++ b/model-samples/max-ocr/max-ocr.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Optical Character Recognition
 model_identifier: max-ocr

--- a/model-samples/max-ocr/max-ocr.yaml
+++ b/model-samples/max-ocr/max-ocr.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Optical Character Recognition

--- a/model-samples/max-question-answering/max-question-answering.yaml
+++ b/model-samples/max-question-answering/max-question-answering.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Question Answering

--- a/model-samples/max-question-answering/max-question-answering.yaml
+++ b/model-samples/max-question-answering/max-question-answering.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Question Answering
 model_identifier: max-question-answering

--- a/model-samples/max-recommender/max-recommender.yaml
+++ b/model-samples/max-recommender/max-recommender.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Recommender System
 model_identifier: max-recommender

--- a/model-samples/max-recommender/max-recommender.yaml
+++ b/model-samples/max-recommender/max-recommender.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Recommender System

--- a/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
+++ b/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Text Sentiment Classifier
 model_identifier: max-text-sentiment-classifier

--- a/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
+++ b/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Text Sentiment Classifier

--- a/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
+++ b/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Toxic Comment Classifier

--- a/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
+++ b/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Toxic Comment Classifier
 model_identifier: max-toxic-comment-classifier

--- a/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
+++ b/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Weather Forecaster
 model_identifier: max-weather-forecaster

--- a/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
+++ b/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Weather Forecaster

--- a/model-samples/template.yaml
+++ b/model-samples/template.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # name: (Required) name of this model file
 # description: (Optional) description of this model file

--- a/model-samples/template.yaml
+++ b/model-samples/template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/notebook-samples/JFK-airport.yaml
+++ b/notebook-samples/JFK-airport.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'jfk-airport-analysis'
 name: 'JFK Airport Analysis'

--- a/notebook-samples/JFK-airport.yaml
+++ b/notebook-samples/JFK-airport.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/aif-bias.yaml
+++ b/notebook-samples/aif-bias.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 # 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/aif-bias.yaml
+++ b/notebook-samples/aif-bias.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 # 
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
-# You may obtain a copy of the License at 
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0 
-# 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'aif360-bias-detection-example'
 name: 'AIF360 Bias detection example'

--- a/notebook-samples/art-detector.yaml
+++ b/notebook-samples/art-detector.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 # 
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
-# You may obtain a copy of the License at 
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0 
-# 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'art-detector-model'
 name: 'ART detector model'

--- a/notebook-samples/art-detector.yaml
+++ b/notebook-samples/art-detector.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 # 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/art-poison.yaml
+++ b/notebook-samples/art-poison.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 # 
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
-# You may obtain a copy of the License at 
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0 
-# 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'art-poisoning-attack'
 name: 'ART poisoning attack'

--- a/notebook-samples/art-poison.yaml
+++ b/notebook-samples/art-poison.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 # 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/codenet-lang.yaml
+++ b/notebook-samples/codenet-lang.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/codenet-lang.yaml
+++ b/notebook-samples/codenet-lang.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'project-codenet-language-classification'
 name: 'Project CodeNet - Language Classification'

--- a/notebook-samples/codenet-mlm.yaml
+++ b/notebook-samples/codenet-mlm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/codenet-mlm.yaml
+++ b/notebook-samples/codenet-mlm.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'project-codenet-mlm'
 name: 'Project CodeNet - MLM'

--- a/notebook-samples/qiskit-ml.yaml
+++ b/notebook-samples/qiskit-ml.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/qiskit-ml.yaml
+++ b/notebook-samples/qiskit-ml.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'qiskit-quantum-kernel-machine-learning'
 name: 'Qiskit Quantum Kernel Machine Learning'

--- a/notebook-samples/qiskit-nncr.yaml
+++ b/notebook-samples/qiskit-nncr.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'qiskit-neural-network-classifier-and-regressor'
 name: 'Qiskit Neural Network Classifier and Regressor'

--- a/notebook-samples/qiskit-nncr.yaml
+++ b/notebook-samples/qiskit-nncr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/notebook-samples/src/notebook-yaml-samples/maintainer.yaml
+++ b/notebook-samples/src/notebook-yaml-samples/maintainer.yaml
@@ -1,16 +1,6 @@
 # Copyright 2019 IBM Corporation 
 # 
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
-# You may obtain a copy of the License at 
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0 
-# 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: 'sklearn-maintainer-model'
 name: 'SKlearn Maintainer model'

--- a/notebook-samples/src/notebook-yaml-samples/maintainer.yaml
+++ b/notebook-samples/src/notebook-yaml-samples/maintainer.yaml
@@ -1,5 +1,5 @@
-# Copyright 2019 IBM Corporation 
-# 
+# Copyright 2021 The MLX Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 id: 'sklearn-maintainer-model'

--- a/notebook-samples/template.yaml
+++ b/notebook-samples/template.yaml
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 id: <notebook_id> # Required, must be DNS-1123 subdomain, lower case alphanumeric characters and '-'
 name: <notebook_name> # Required

--- a/notebook-samples/template.yaml
+++ b/notebook-samples/template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pipeline-samples/calculation-pipeline.yaml
+++ b/pipeline-samples/calculation-pipeline.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:

--- a/pipeline-samples/flip-coin-pipeline.yaml
+++ b/pipeline-samples/flip-coin-pipeline.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:

--- a/pipeline-samples/katib-pipeline.yaml
+++ b/pipeline-samples/katib-pipeline.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:

--- a/pipeline-samples/kfp-notebook/kfp_notebook.py
+++ b/pipeline-samples/kfp-notebook/kfp_notebook.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pipeline-samples/kfp-notebook/kfp_notebook.py
+++ b/pipeline-samples/kfp-notebook/kfp_notebook.py
@@ -1,16 +1,6 @@
 # Copyright 2021 IBM Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 import kfp

--- a/pipeline-samples/nested-pipeline.yaml
+++ b/pipeline-samples/nested-pipeline.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:

--- a/pipeline-samples/trusted-ai-pipeline.yaml
+++ b/pipeline-samples/trusted-ai-pipeline.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:

--- a/pipeline-samples/wml-pipeline.yaml
+++ b/pipeline-samples/wml-pipeline.yaml
@@ -1,3 +1,6 @@
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:

--- a/tools/bash/add_license_headers.sh
+++ b/tools/bash/add_license_headers.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The MLX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+hash_comment () {
+  echo "$1"
+  if ! grep -q "SPDX-License-Identifier" "$1"
+  then
+    sed -i '' '1i\
+    # Copyright 2021 The MLX Contributors\
+    #\
+    # SPDX-License-Identifier: Apache-2.0\
+    ' "$1"
+  fi
+}
+
+slash_comment () {
+  echo "$1"
+  if ! grep -q "SPDX-License-Identifier" "$1"
+  then
+    sed -i '' '1i\
+    // Copyright 2021 The MLX Contributors\
+    //\
+    // SPDX-License-Identifier: Apache-2.0\
+    ' "$1"
+  fi
+}
+
+css_comment () {
+  echo "$1"
+  if ! grep -q "SPDX-License-Identifier" "$1"
+  then
+    sed -i '' '1i\
+    /*\
+    * Copyright 2021 The MLX Contributors\
+    *\
+    * SPDX-License-Identifier: Apache-2.0\
+    */\
+    ' "$1"
+  fi
+}
+
+html_comment () {
+  echo "$1"
+  if ! grep -q "SPDX-License-Identifier" "$1"
+  then
+    sed -i '' '1i\
+    <!--\
+      Copyright 2021 The MLX Contributors\
+      \
+      SPDX-License-Identifier: Apache-2.0\
+    -->\
+    ' "$1"
+  fi
+}
+
+export -f hash_comment slash_comment css_comment html_comment
+
+echo "Adding missing license headers"
+
+# Python, YAML, Bash
+find . -type f -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.py' -o -name '*.yaml' -o -name '*.yml' -o -name '*.sh' \) -exec bash -c 'hash_comment "$0"' {} \;
+
+# Javascript
+find . -type f -not -path '*/node_modules/*' -a -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.js' -o -name '*.ts' \) -exec bash -c 'slash_comment "$0"' {} \;
+
+# CSS
+find . -type f -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.css' -o -name '*.tsx' \) -exec bash -c 'css_comment "$0"' {} \;
+
+# HTML
+find . -type f -not -path '*/temp/*' -a -not -path '*/\.*' -a -name '*.html' -exec bash -c 'html_comment "$0"' {} \;

--- a/tools/python/verify_doc_links.py
+++ b/tools/python/verify_doc_links.py
@@ -2,17 +2,7 @@
 
 # Copyright 2021 IBM
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import concurrent.futures
 import itertools

--- a/tools/python/verify_doc_links.py
+++ b/tools/python/verify_doc_links.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 IBM
+# Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Converting license header to SPDX format, as was done in the MLX repo (machine-learning-exchange/mlx#210)

This will ensure that the YAML files visible in the MLX UI will no longer show the Apache License header, but the equivalent SPDX short form, freeing up valuable screen real-estate.

Those YAML files which previously did not have a license header will now have it.

**Before:**
```YAML
# Copyright 2021 IBM Corporation
# 
# Licensed under the Apache License, Version 2.0 (the "License"); 
# you may not use this file except in compliance with the License. 
# You may obtain a copy of the License at 
# 
#     http://www.apache.org/licenses/LICENSE-2.0 
# 
# Unless required by applicable law or agreed to in writing, software 
# distributed under the License is distributed on an "AS IS" BASIS, 
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
# See the License for the specific language governing permissions and 
# limitations under the License.

id: 'art-detector-model'
name: 'ART detector model'
...
```

**After:**
```YAML
# Copyright 2021 IBM Corporation
# 
# SPDX-License-Identifier: Apache-2.0

id: 'art-detector-model'
name: 'ART detector model'
...
```



**Related issues:**

- #44
- machine-learning-exchange/mlx#210
