### PR TITLE
Check URLs in YAML files

### DIFF
--- a/model-samples/max-ocr/max-ocr.md
+++ b/model-samples/max-ocr/max-ocr.md
@@ -68,8 +68,8 @@ $ curl -F "image=@samples/quick_start_watson_studio.jpg" -XPOST http://localhost
     ],
     [
       "Watson Studio is IBM’s hosted notebook service, and you can create",
-      "a free account at https://www.ibm.com/cloud/watson-studio. Other",
-      "hosted notebook services can be used to run the noteooks as well,",
+      "a free account at https://www.ibm.com/cloud/watson-studio/. Other",
+      "hosted notebook services can be used to run the notebooks as well,",
       "but Watson Studio offers all of the frameworks and languages that",
       "are used for this book’s examples. Once you have created an account",
       "and logged in, you can begin by creating a project and notebook."

--- a/model-samples/template.yaml
+++ b/model-samples/template.yaml
@@ -1,7 +1,7 @@
 # Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-#
+
 # name: (Required) name of this model file
 # description: (Optional) description of this model file
 # author: (Required for trainable)
@@ -35,8 +35,8 @@ framework:
 # website:  (Optional) Links that explain this model in more details
 
 license: "Apache 2.0"
-domain: "Facial Recognition"
-website: "https://developer.ibm.com/exchanges/models/all/max-facial-age-estimator"
+domain: "Image Recognition"
+website: "https://developer.ibm.com/exchanges/models/all/max-image-caption-generator"
 labels:
   - url:
   - pipeline_uuids: ["abcd1234"]


### PR DESCRIPTION
All too often there are typos in URLs or links run out of date. This is especially bad when MLX requires the URL to load resources like:
- `related assets` 
- `readme_url`

This PR adds YAML files to the existing script `tools/python/verify_doc_links.py` which is invoked via the `check_doc_links` `make` target.

Resolves #43