### PR TITLE
Remove Colab links

### DIFF
--- a/dataset-samples/codenet/codenet.md
+++ b/dataset-samples/codenet/codenet.md
@@ -49,7 +49,6 @@ analysis Python notebooks to help you get started:
 This notebook takes you through the steps of a simple experiment that shows how to create and exercise a Keras model to detect the language of a piece of source code. 
 
 [Get the notebook](https://github.com/CODAIT/project-codenet-notebooks/blob/main/Project_CodeNet_LangClass.ipynb)
-[Run the notebook in Colab](https://colab.research.google.com/github/CODAIT/project-codenet-notebooks/blob/main/Project_CodeNet_LangClass.ipynb)
 
 ### Notebook 2: A Masked Language Model for Project CodeNet
 

--- a/dataset-samples/codenet_langclass/codenet_langclass.md
+++ b/dataset-samples/codenet_langclass/codenet_langclass.md
@@ -51,7 +51,6 @@ analysis Python notebooks to help you get started:
 This notebook takes you through the steps of a simple experiment that shows how to create and exercise a Keras model to detect the language of a piece of source code. 
 
 [Get the notebook](https://github.com/CODAIT/project-codenet-notebooks/blob/main/Project_CodeNet_LangClass.ipynb)
-[Run the notebook in Colab](https://colab.research.google.com/github/CODAIT/project-codenet-notebooks/blob/main/Project_CodeNet_LangClass.ipynb)
 
 ### Notebook 2: A Masked Language Model for Project CodeNet
 

--- a/dataset-samples/codenet_mlm/codenet_mlm.md
+++ b/dataset-samples/codenet_mlm/codenet_mlm.md
@@ -51,7 +51,6 @@ analysis Python notebooks to help you get started:
 This notebook takes you through the steps of a simple experiment that shows how to create and exercise a Keras model to detect the language of a piece of source code. 
 
 [Get the notebook](https://github.com/CODAIT/project-codenet-notebooks/blob/main/Project_CodeNet_LangClass.ipynb)
-[Run the notebook in Colab](https://colab.research.google.com/github/CODAIT/project-codenet-notebooks/blob/main/Project_CodeNet_LangClass.ipynb)
 
 ### Notebook 2: A Masked Language Model for Project CodeNet
 


### PR DESCRIPTION
Remove Google Colab links from CodeNet dataset pages. 
cc: @ckadner 