### PR TITLE
Add description to `create-model-config` component

### DIFF
--- a/component-samples/model-config/component.yaml
+++ b/component-samples/model-config/component.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 name: Create Model Config
-description:
+description: Create a ConfigMap to deploy a model on Kubernetes
 inputs:
   - {name: secret_name,         type: String, default: 'e2e-creds',   description: 'Secret name to generate for model training/deployment'}
   - {name: model_id,            type: String, default: 'sampleid',    description: 'MLX Model ID'}


### PR DESCRIPTION
Reported by @ptitzler:

> Is the description in this example component empty on purpose? 
https://github.com/machine-learning-exchange/katalog/blob/main/component-samples/model-config/component.yaml#L5

Possible descriptions:

- [ ] "Set up model deployment configmap on Kubernetes"
- [ ] "Configure model deployment on Kubernetes"
- [x] "Create a ConfigMap to deploy a model on Kubernetes"

@yhwang @Tomcli @ptitzler -- if you have other/better suggestions please let me know