### PR TITLE
Add container_port to model YAML

### DIFF
--- a/component-samples/model-config/src/model-config.py
+++ b/component-samples/model-config/src/model-config.py
@@ -122,7 +122,7 @@ def generateKnativeDeployParams(model_dict, param_path):
         'deployment_name': model_dict['model_identifier'],
         'model_class_name': '',
         'model_class_file': '',
-        'container_port': '5000',
+        'container_port': model_dict['serve']['serving_container_image'].get('container_port', '5000'),
         'traffic_route_name': 'knative-demo',
         'primary_model_revision': model_dict['model_identifier'] + '-00001',
         'traffic_percentage': '5'
@@ -146,10 +146,13 @@ def generateKFServingDeployParams(model_dict, param_path):
     kfserving_params = {
         'model_serving_image': model_dict['serve']['serving_container_image']['container_image_url'],
         'deployment_name': model_dict['model_identifier'],
-        'container_port': '5000',
-        'default_custom_model_spec': json.dumps({"name": model_dict['model_identifier'],
-                                      "image": model_dict['serve']['serving_container_image']['container_image_url'],
-                                      "port": "5000"})
+        'container_port': model_dict['serve']['serving_container_image'].get('container_port', '5000'),
+        'default_custom_model_spec':
+            json.dumps({
+                "name": model_dict['model_identifier'],
+                "image": model_dict['serve']['serving_container_image']['container_image_url'],
+                "port": model_dict['serve']['serving_container_image'].get('container_port', '5000')
+            })
     }
 
     for key, value in kfserving_params.items():
@@ -161,7 +164,7 @@ def generateKubeDeployParams(model_dict, param_path):
         'deployment_name': model_dict['model_identifier'],
         'model_class_name': '',
         'model_class_file': '',
-        'container_port': '5000',
+        'container_port': model_dict['serve']['serving_container_image'].get('container_port', '5000'),
         'traffic_route_name': 'knative-demo',
     }
 
@@ -233,9 +236,11 @@ if __name__ == "__main__":
         for item in model_dict['serve']['tested_platforms']:
             if item.lower() == 'knative':
                 generateKnativeDeployParams(model_dict, param_path)
-            if item.lower() == 'kubernetes':
+            elif item.lower() == 'kubernetes':
                 generateKubeDeployParams(model_dict, param_path)
-            if item.lower() == 'kfserving' or True:
+            elif item.lower() == 'kfserving':
+                generateKFServingDeployParams(model_dict, param_path)
+            else:
                 generateKFServingDeployParams(model_dict, param_path)
 
     # Generate secret for the pipeline

--- a/model-samples/README.md
+++ b/model-samples/README.md
@@ -31,6 +31,7 @@ framework:
 license: "Apache 2.0"
 domain: "Domain Area"
 website: <model_website> # Can be GitHub link
+readme_url: <readme_url> # Optional, GitHub "Raw"-URL, Github-flavored markdown to be displayed as Description in MLX UI
 
 train:
   trainable: true
@@ -82,6 +83,7 @@ framework:
 license: "Apache 2.0"
 domain: "Domain Area"
 website: <model_website> # Can be GitHub link
+readme_url: <readme_url> # Optional, GitHub "Raw"-URL, Github-flavored markdown to be displayed as Description in MLX UI
 
 serve:
   servable: true
@@ -90,6 +92,7 @@ serve:
     - knative
   serving_container_image:
     container_image_url: <model_docker_image>
+    container_port: 5000
 ```
 
 ## Register Model

--- a/model-samples/codenet-language-classification/codenet-language-classification.yaml
+++ b/model-samples/codenet-language-classification/codenet-language-classification.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "codait/codenet-language-classifier"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/codenet-language-classification/codenet-language-classification.md

--- a/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
+++ b/model-samples/max-human-pose-estimator/max-human-pose-estimator.yaml
@@ -26,5 +26,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-human-pose-estimator:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-human-pose-estimator/max-human-pose-estimator.md

--- a/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
+++ b/model-samples/max-image-caption-generator/max-image-caption-generator.yaml
@@ -24,5 +24,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-image-caption-generator:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-image-caption-generator/max-image-caption-generator.md

--- a/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
+++ b/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-image-resolution-enhancer:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-image-resolution-enhancer/max-image-resolution-enhancer.md

--- a/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
+++ b/model-samples/max-named-entity-tagger/max-named-entity-tagger.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-named-entity-tagger:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-named-entity-tagger/max-named-entity-tagger.md

--- a/model-samples/max-object-detector/max-object-detector.yaml
+++ b/model-samples/max-object-detector/max-object-detector.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-object-detector:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-object-detector/max-object-detector.md

--- a/model-samples/max-ocr/max-ocr.yaml
+++ b/model-samples/max-ocr/max-ocr.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-ocr:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-ocr/max-ocr.md

--- a/model-samples/max-question-answering/max-question-answering.yaml
+++ b/model-samples/max-question-answering/max-question-answering.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-question-answering:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-question-answering/max-question-answering.md

--- a/model-samples/max-recommender/max-recommender.yaml
+++ b/model-samples/max-recommender/max-recommender.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-recommender:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-recommender/max-recommender.md

--- a/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
+++ b/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-text-sentiment-classifier:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-text-sentiment-classifier/max-text-sentiment-classifier.md

--- a/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
+++ b/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.yaml
@@ -20,5 +20,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-toxic-comment-classifier:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-toxic-comment-classifier/max-toxic-comment-classifier.md

--- a/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
+++ b/model-samples/max-weather-forecaster/max-weather-forecaster.yaml
@@ -19,5 +19,6 @@ serve:
     - kfserving
   serving_container_image:
     container_image_url: "quay.io/codait/max-weather-forecaster:latest"
+    container_port: "5000"
 
 readme_url: https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-weather-forecaster/max-weather-forecaster.md

--- a/model-samples/template.yaml
+++ b/model-samples/template.yaml
@@ -33,6 +33,7 @@ framework:
 # license: (Optional) License for this model.
 # domain: (Optional) Domain metadata for this model.
 # website:  (Optional) Links that explain this model in more details
+# readme_url: (Optional) A GitHub-flavored markdown file to be rendered in the MLX UI
 
 license: "Apache 2.0"
 domain: "Image Recognition"
@@ -40,6 +41,7 @@ website: "https://developer.ibm.com/exchanges/models/all/max-image-caption-gener
 labels:
   - url:
   - pipeline_uuids: ["abcd1234"]
+readme_url: "https://raw.githubusercontent.com/IBM/MAX-Facial-Age-Estimator/master/README.md"
 
 # train: (optional)
 #   trainable: (optional) Indicate the model is trainable. Default: False
@@ -150,6 +152,7 @@ train:
 #       path: (Optional) Servable model path in the user local machine
 #   serving_container_image: (Required for container type)
 #     container_image_url: (Required for container type) Container image to serve the model.
+#     container_port: (Optional) Container port serving inferencing request. Default: 5000
 #     container_store: (Optional) container_store name
 
 serve:
@@ -168,6 +171,7 @@ serve:
       path: /local/1.0/assets/
   serving_container_image:
     container_image_url: "codait/max-facial-age-estimator:latest"
+    container_port: "5000"
     container_store: container_store
 
 # data (Optional) metadata for model training data

--- a/notebook-samples/codenet-lang.yaml
+++ b/notebook-samples/codenet-lang.yaml
@@ -11,5 +11,5 @@ metadata:
 implementation:
   github:
     source: 'https://github.com/machine-learning-exchange/katalog/blob/main/notebook-samples/src/codenet/Project_CodeNet_LangClass.ipynb'
-    requirements: 'keras==2.7.0,matplotlib==3.5.1,numpy==1.21.4,tensorflow==2.7.0'
+    requirements: 'keras==2.7.0,matplotlib==3.5.1,numpy==1.21.4,tensorflow==2.7.0,Jinja2==3.0.3'
     image: 'tensorflow/tensorflow:2.7.0'

--- a/notebook-samples/codenet-mlm.yaml
+++ b/notebook-samples/codenet-mlm.yaml
@@ -11,5 +11,5 @@ metadata:
 implementation:
   github:
     source: 'https://github.com/machine-learning-exchange/katalog/blob/main/notebook-samples/src/codenet/Project_CodeNet_MLM.ipynb'
-    requirements: 'keras==2.7.0,matplotlib==3.5.1,pandas==1.3.5,tensorflow==2.7.0'
+    requirements: 'keras==2.7.0,matplotlib==3.5.1,pandas==1.3.5,tensorflow==2.7.0,Jinja2==3.0.3'
     image: 'tensorflow/tensorflow:2.7.0'


### PR DESCRIPTION
Currently, when models are served via the "Launch" tab of the MLX UI, the container port is fixed and assumed to be `5000`. This works for the containerized MAX models, all of which serve inferencing requests on port 5000. However any other models to be registered in MLX that are not listening on port 5000 would have to be rebuild before they can be registered and deployed in MLX. 

This PR introduces a new optional field to the model YAML to allow users to specify the port on which the containerized model listens to inferencing requests.

There will be another PR on the `mlx` repo shortly to make use of the container port parameter in the built-in model deployment pipeline.

/cc @Tomcli @rafvasq 

